### PR TITLE
Update website and documentation links in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,7 +138,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 -- **Website**: [onchainbets.fun](https://onchainbets.fun)
 -- **Documentation**: [onchainbets.fun/docs](https://www.onchainbets.fun/docs)
 - **X/Twitter Community**: [Join our community](https://x.com/i/communities/1959009958617334252)
-- **X/Twitter**: [Follow us](https://x.com/i/communities/1958007698534068643/)
+- **X/Twitter**: [Follow us](https://x.com/Onchainbetsfun)
 
 ## ⚠️ Disclaimer
 


### PR DESCRIPTION
This pull request updates the external links in the `readme.md` file to reflect the current website and documentation URLs, as well as the correct X/Twitter account for the project.

Documentation and website links update:

* Changed the website link from `onchainbets.live` to `onchainbets.fun` and updated the documentation link to `onchainbets.fun/docs`.

Social media links update:

* Updated the X/Twitter link to point to the correct project account (`Onchainbetsfun`) and removed the outdated community link.