### PR TITLE
Enable TrollBox and update chat header

### DIFF
--- a/src/components/TrollBox.tsx
+++ b/src/components/TrollBox.tsx
@@ -328,7 +328,7 @@ export default function TrollBox() {
       )}
       <ContentContainer $isMinimized={isMinimized}>
         <Header onClick={toggleMinimize}>
-          <HeaderTitle>Chat</HeaderTitle>
+          <HeaderTitle>Community Chat</HeaderTitle>
           <HeaderStatus>
             {messages.length ? `${messages.length} msgs` : 'Connecting…'}
           </HeaderStatus>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -205,7 +205,7 @@ export const TOKEN_METADATA_FETCHER = (() => {
 })();
 
 export const ENABLE_LEADERBOARD = true;
-export const ENABLE_TROLLBOX = false; // Requires setup in vercel (check tutorial in discord)
+export const ENABLE_TROLLBOX = true; // Requires setup in vercel (check tutorial in discord)
 
 /** If true, the featured game is fully playable inline on the dashboard */
 export const FEATURED_GAME_INLINE = false;


### PR DESCRIPTION
Changed the chat header title to 'Community Chat' in TrollBox and enabled the TrollBox feature in constants. This makes the chat feature available and updates its presentation.