### PR TITLE
Improve error logging and disable Trollbox feature

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -26,7 +26,7 @@ export default async function handler(req: Request): Promise<Response> {
     }
     return new Response('Method Not Allowed', { status: 405 })
   } catch (err: any) {
-    console.error('[chat API error]', err);
+    console.error('[chat API error]', err?.stack || err);
     return new Response('Internal Error', { status: 500 })
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -205,7 +205,7 @@ export const TOKEN_METADATA_FETCHER = (() => {
 })();
 
 export const ENABLE_LEADERBOARD = true;
-export const ENABLE_TROLLBOX = true; // Requires setup in vercel (check tutorial in discord)
+export const ENABLE_TROLLBOX = false; // Requires setup in vercel (check tutorial in discord)
 
 /** If true, the featured game is fully playable inline on the dashboard */
 export const FEATURED_GAME_INLINE = false;


### PR DESCRIPTION
Error logging in the chat API now outputs stack traces when available for better debugging. The Trollbox feature is disabled in constants, likely due to missing setup requirements.